### PR TITLE
Tweak whitelisted licenses

### DIFF
--- a/.wwhrd.yml
+++ b/.wwhrd.yml
@@ -3,7 +3,8 @@ whitelist:
   - Apache-2.0
   - FreeBSD
   - MIT
-  - NewBSD
+  - BSD-2-Clause
+  - BSD-3-Clause
 
 exceptions:
   - github.com/pelletier/go-buffruneio # Uses the "MIT" license


### PR DESCRIPTION
Wwhrd changed its license detection library. The new library detects the previous "NewBSD" as "BSD-2-Clause" and "BSD-3-Clause".