### PR TITLE
Use latest go version for release

### DIFF
--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -26,6 +26,10 @@ jobs:
     needs: bump-version
     steps:
       -
+        uses: arnested/go-version-action@v1
+        id: go-version
+
+      -
         name: Checkout
         uses: actions/checkout@v3
         with:
@@ -34,7 +38,7 @@ jobs:
         name: Set up Go
         uses: actions/setup-go@v3
         with:
-          go-version: "1.15"
+          go-version: ${{ steps.go-version.outputs.latest }}
       -
         name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v2.9.1


### PR DESCRIPTION
Should have been part of dce6ae865aad524dbb8d23bc1cd29eae7f2dc302.
