### PR TITLE
Use Homebrew service instead of deprecated plist_options

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -38,21 +38,6 @@ brews:
     description: "Create iTerm2 dynamic profile from SSH config"
     install: |
       bin.install "ssh2iterm2"
-    plist: |
-      <?xml version="1.0" encoding="UTF-8"?>
-      <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-      <plist version="1.0">
-        <dict>
-          <key>Label</key>
-          <string>#{plist_name}</string>
-          <key>ProgramArguments</key>
-          <array>
-            <string>#{opt_bin}/ssh2iterm2</string>
-            <string>watch</string>
-          </array>
-          <key>RunAtLoad</key>
-          <true/>
-          <key>KeepAlive</key>
-          <true/>
-        </dict>
-      </plist>
+    service: |
+      run [opt_bin/"ssh2iterm2", "watch"]
+      keep_alive true


### PR DESCRIPTION
Fixes arnested/homebrew-ssh2iterm2#1

Thank you, @mariopaumann!