### PR TITLE
Update Go version to 1.25.2

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/arnested/ssh2iterm2
 
-go 1.25.1
+go 1.25.2
 
 require (
 	github.com/carlmjohnson/versioninfo v0.22.5


### PR DESCRIPTION
Update Go version to 1.25.2.

See [the release history](https://go.dev/doc/devel/release#go1.25.2).