### PR TITLE
Update Go version to 1.26.2

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/arnested/ssh2iterm2
 
-go 1.26.1
+go 1.26.2
 
 require (
 	github.com/carlmjohnson/versioninfo v0.22.5


### PR DESCRIPTION
Update Go version to 1.26.2.

See [the release history](https://go.dev/doc/devel/release#go1.26.2).